### PR TITLE
Add new function in Tools/MPDcheck to check if @mimeType is set correctly.

### DIFF
--- a/Tools/MPDcheck/TestFramework.css
+++ b/Tools/MPDcheck/TestFramework.css
@@ -42,15 +42,21 @@ and open the template in the editor.
             color: #A0522D;
         }
         #outputs{
-             position: absolute;
+            position: absolute;
             left: 910px;
             top: 103px;
         }
-         #results{
-             position: absolute;
+        #results{
+            position: absolute;
             left: 920px;
             top: 110px;
-             font-size: 120%;
+            font-size: 120%;
+        }
+        #results2{
+            position: absolute;
+            left: 1120px;
+            top: 110px;
+            font-size: 120%;
         }
         #Checkbox{
             position: absolute;

--- a/Tools/MPDcheck/index.php
+++ b/Tools/MPDcheck/index.php
@@ -44,17 +44,23 @@
                 var div = '<div id= ' + id + ' style="position: absolute;left:1000px; top:' + top + ';"></div>';
                 document.body.insertAdjacentHTML('beforeend', div);
                 document.getElementById('statusContent').innerHTML = "Running vector " + i;
+                
+                //another column for test results
+                var id2 = 'resultDiv' + (i+vectors.length);
+                var div2 = '<div id= ' + id2 + ' style="position: absolute;left:1200px; top:' + top + ';"></div>';
+                document.body.insertAdjacentHTML('beforeend', div2);
 
                 $.post(
                     "loadMPD.php",
                     {url: vectors[i - 1]}
                 ).done(function (response) {
-                    console.log(response);
+//                    console.log(response);
                     
                     if (response.trim() !== 'error')
                     {
                         var xml = $.parseXML(response);
                         checkContentType(xml);
+                        checkMimeType(xml);
                     }else
                     {
                         $('#' + id).prepend('<b>Broken Link</b>');
@@ -81,7 +87,6 @@
                     {
                         $('#' + id).prepend('<img id="theImg" src="button_cancel.png" />');
                         document.getElementById('statusContent').innerHTML = "Completed vector " + i;
-//                        j++;
                         resultDivNum = i+1;
 //                        alert("@contentType missing for Test Vector " + i);
                     }
@@ -89,9 +94,163 @@
                     {
                         $('#' + id).prepend('<img id="theImg" src="right.jpg" />');
                         document.getElementById('statusContent').innerHTML = "Completed vector " + i;
-//                        j++;
                         resultDivNum = i+1;
                     }
+                }
+                
+                
+                function checkMimeType(xmlDoc) {
+                    var mimeTypeError = false;
+                    //go through every Period
+                    var periods = xmlDoc.getElementsByTagName("Period");
+                    for (var k = 0; k < periods.length; k++)
+                    {
+                        //loop every Adaptation set
+                        var adaptSets = periods[k].getElementsByTagName("AdaptationSet");
+                        if (adaptSets.length === 0) //used for handling xlink etc.
+                        {
+                            //don't show warning if remote element is contained
+                            if (!periods[k].getElementsByTagName("xlink:href") || !periods[k].getElementsByTagName("xlink:actuate"))
+                            {
+                                console.log("Warning: no Adaptation set in Period " + k + " for Test Vector " + i);
+                            }
+                            continue;
+                        }
+                        var numVideo = 0;
+                        var numAudio = 0;
+                        for (var m = 0; m < adaptSets.length; m++)
+                        {
+                            var mimeType = adaptSets[m].getAttribute("mimeType");
+                            var numSubVideo = 0;
+                            var numSubAudio = 0;
+                            if (!mimeType)
+                            {
+                                //search @mimeType in corresponding Representation Sets if not present in Adaptation set
+                                var repSets = adaptSets[m].getElementsByTagName("Representation");
+                                if (repSets.length === 0)
+                                {
+                                    console.log("Warning: @mimeType missing in Period " + k + " Adaptation set " + m + " for Test Vector " + i);
+                                    mimeTypeError = true;
+                                    continue;
+                                }
+                                for (var n = 0; n < repSets.length; n++)
+                                {
+                                    var subMimeType = repSets[n].getAttribute("mimeType");
+                                    if (!subMimeType)
+                                    {
+                                        console.log("Warning: @mimeType missing in Period " + k + " Adaptation set " + m + " Representation set " + n + " for Test Vector " + i);
+                                        mimeTypeError = true;
+                                    }
+                                    else
+                                    {
+                                        if(subMimeType === "video/mp4")
+                                        {
+                                            numSubVideo++;
+                                        }
+                                        else if(subMimeType === "audio/mp4")
+                                        {
+                                            numSubAudio++;
+                                        }
+                                        else
+                                        {
+                                            console.log("Warning: unknown @mimeType \"" + subMimeType + "\" in Period " + k + " Adaptation set " + m + " Representation set " + n + " for Test Vector " + i);
+                                            mimeTypeError = true;
+                                        }
+                                    }
+                                }
+                                if (numSubVideo>0)
+                                {
+                                    numVideo++;
+                                }
+                                if (numSubAudio>0)
+                                {
+                                    numAudio++;
+                                }
+                            }
+                            else
+                            {
+                                if(mimeType === "video/mp4")
+                                {
+                                    numVideo++;
+                                }
+                                else if(mimeType === "audio/mp4")
+                                {
+                                    numAudio++;
+                                }
+                                else
+                                {
+                                    console.log("Warning: unknown @mimeType \"" + mimeType + "\" in Period " + k + " Adaptation set " + m + " for Test Vector " + i);
+                                    mimeTypeError = true;
+                                }
+                            }
+                        }
+                        if (numAudio<1)
+                        {
+                            console.log("Warning: no Adaptation set with @mimeType=\"audio/mp4\" in Period " + k + " for Test Vector " + i);
+                            mimeTypeError = true;
+                        }
+                        if (numVideo>1) //TODO is it acceptable that number of video adapt. set == 0 (audio only)?
+                        {
+                            //we need to verify if it's caused by trick mode
+//                            console.log("Period " + k + ":");
+                            if (!inTrickMode(periods[k], numVideo))
+                            {
+                                console.log("Warning: too many Adaptation sets with @mimeType=\"video/mp4\" in Period " + k + " for Test Vector " + i);
+                                mimeTypeError = true;
+                            }
+                        }
+                    }
+                    
+                    if (mimeTypeError)
+                    {
+                        $('#' + id2).prepend('<img id="theImg" src="button_cancel.png" />');
+                        document.getElementById('statusContent').innerHTML = "Completed vector " + i;
+                        resultDivNum = i+vectors.length+1;
+                    }
+                    else
+                    {
+                        $('#' + id2).prepend('<img id="theImg" src="right.jpg" />');
+                        document.getElementById('statusContent').innerHTML = "Completed vector " + i;
+                        resultDivNum = i+vectors.length+1;
+                    }
+                }
+                
+                
+                //NOTE: here we only verify additional video Adaptation set 
+                function inTrickMode(xmlDoc, numVideo)
+                {
+                    var essentialP = xmlDoc.getElementsByTagName("EssentialProperty");
+                    var supplementalP = xmlDoc.getElementsByTagName("SupplementalProperty");
+                    var numTrickMode = 0;
+                    if (essentialP.length === 0 && supplementalP.length === 0)
+                    {
+                        return false;
+                    }
+                    
+                    if (essentialP.length > 0)
+                    {
+                        for (var m = 0; m < essentialP.length; m++)
+                        {
+                            var uri = essentialP[m].getAttribute("schemeIdUri");
+                            if (uri === "http://dashif.org/guidelines/trickmode")
+                                numTrickMode++;
+                        }
+                    }
+                    
+                    if (supplementalP.length > 0)
+                    {
+                        for (var m = 0; m < supplementalP.length; m++)
+                        {
+                            var uri = essentialP[m].getAttribute("schemeIdUri");
+                            if (uri === "http://dashif.org/guidelines/trickmode")
+                                numTrickMode++;
+                        }
+                    }
+                    
+                    if (numTrickMode === numVideo - 1) //TODO check if corresponding @value is set correctly
+                        return true;
+                    
+                    return false;
                 }
             }
             else  // Creating Reference results.
@@ -106,10 +265,11 @@
 <p id="Testvectors">Test vectors :</p><br>
 <textarea name="Text1" cols="110" rows="40" id='vectors'></textarea>
 <br><input type=button id="Start" value="Start Testing" onclick="testing()">  
-<div id="tick" style="position: absolute; left: 900px"></div>
+<!--<div id="tick" style="position: absolute; left: 900px"></div>-->
 <p id="status">Status :</p>
 <p id="statusContent"></p>
 <p id="results">@contentType exists?</p>
+<p id="results2">@mimeType correct?</p>
 </body>
 
 </html>

--- a/webfe/conformancetest.php
+++ b/webfe/conformancetest.php
@@ -1,4 +1,18 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!--This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
     <meta charset="utf-8" />
     <head>

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -39,7 +39,7 @@ function process_mpd() {
                 if ((string)$tempXML->completed === "true"){
                     $change1 = time() - (int)$tempXML->completed->attributes(); 
                 }
-                if ($change1 > 300 || $change2 > 1800)  //clean folder after 5 mins after test completed or 30 mins after test started
+                if ($change1 > 1800 || $change2 > 1800)  //clean folder after 30 mins after test completed or 30 mins after test started
                     rrmdir(dirname(__FILE__) . '/' . 'temp' . '/' . $file); // if last time folder was modified exceed 300 second it should be removed 
             }
         }

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -47,8 +47,12 @@ function process_mpd() {
         // Work out which validator binary to use
         $validatemp4 = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? "validatemp4-vs2010.exe" : "ValidateMP4.exe";
         //var_dump( $path_parts  );
-        if (isset($_POST['foldername']))
+        if (isset($_POST['foldername'])){
             $foldername=$_POST['foldername'];
+            $paths = split("/", $foldername);
+            if(count($paths)>1)
+                $foldername = end($paths);
+        }
         else
             $foldername = 'id' . rand(); // get random name for session folder
          //get a name for session folder from client.


### PR DESCRIPTION
The main purpose is to check in each period, if zero or one Adaptation set with @mimeType="video/mp4" and at least one Adaptation set with @mimeType="audio/mp4" are present. For many mpds in which the @mimeType is not defined in Adaptation set level, the check is done to every Representation set. The sub-representation set level is not considered yet. 

Some special cases:
- in trick mode, there can be more than one Adaptation set with @mimeType="video/mp4". The tool checks the number of such Adaptation sets and verifies only one of them is not in trick mode.
- if any period is defined by xlink (remote element), it is excluded from the check.
- for audio only mpds, we permit the absence of Adaptation set with @mimeType="video/mp4" 

The general test results are shown in the GUI and the details can be found in the browser console.

----------------------------------------------------

New: for security, disallow relative path if the temp folder name is user defined. Only the last part of the name will be taken in such case and all the results folder would be stored directly in the folder "temp".

E.g. if the user wants to use folder name "../xx" or "yy/xx", then the name would be just "xx" under the "temp" folder.

------------------------------------------------------

Update: add changes regarding issue #142