### PR TITLE
Conformance for resolve-to-zero periods

### DIFF
--- a/webfe/mpdvalidator/schematron/output/val_schema.xsl
+++ b/webfe/mpdvalidator/schematron/output/val_schema.xsl
@@ -518,12 +518,12 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
-         <xsl:when test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList)) then false() else true()"/>
+         <xsl:when test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList) and not(@xlink:href = 'urn:mpeg:dash:resolve-to-zero:2013')) then false() else true()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
                                 xmlns:schold="http://www.ascc.net/xml/schematron"
                                 xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList)) then false() else true()">
+                                test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList) and not(@xlink:href = 'urn:mpeg:dash:resolve-to-zero:2013')) then false() else true()">
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>

--- a/webfe/mpdvalidator/schematron/schematron.xsd
+++ b/webfe/mpdvalidator/schematron/schematron.xsd
@@ -47,7 +47,7 @@
 			<!-- R2.4 -->
 			<assert test="if (not(@id) and ancestor::dash:MPD/@type = 'dynamic') then false() else true()">If the MPD is dynamic the Period element shall have an id.</assert>
 			<!-- R2.5 -->
-			<assert test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList)) then false() else true()">At least one BaseURL, SegmentTemplate or SegmentList shall be defined in Period, AdaptationSet or Representation.</assert>
+			<assert test="if (not(descendant-or-self::dash:BaseURL) and not(descendant-or-self::dash:SegmentTemplate) and not(descendant-or-self::dash:SegmentList) and not(@xlink:href = 'urn:mpeg:dash:resolve-to-zero:2013')) then false() else true()">At least one BaseURL, SegmentTemplate or SegmentList shall be defined in Period, AdaptationSet or Representation.</assert>
             		<assert test="if (@duration = 0 and count(child::dash:AdaptationSet)) then false() else true()">If the duration attribute is set to zero, there should only be a single AdaptationSet present.</assert>
 			<!-- RD2.0	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and dash:SegmentList) then false() else true()">DASH-IF IOP Section 3.2.2: "the Period.SegmentList element shall not be present" violated here </assert>

--- a/webfe/mpdvalidator/src/Definitions.java
+++ b/webfe/mpdvalidator/src/Definitions.java
@@ -35,6 +35,7 @@ public class Definitions {
 	public final static String HREF = "href";
 	public final static String PROTOCOL = "http://";
 	public final static String SECURE_PROTOCOL = "https://";
+	public final static String RESOLVE_TO_ZERO = "urn:mpeg:dash:resolve-to-zero:2013";
 	public static String tmpOutputFile_ = "";
 	
 	// needed for Step 2 and 3: Schema validation and Schematron validation

--- a/webfe/mpdvalidator/src/XLinkResolver.java
+++ b/webfe/mpdvalidator/src/XLinkResolver.java
@@ -87,7 +87,8 @@ public class XLinkResolver {
 				if (Definitions.debug_)
 					printNode(nNode);
 				String link = extractXLinkHref(nNode);
-				if (link != null) {
+				String resolveToZeroPeriod = new String("urn:mpeg:dash:resolve-to-zero:2013");
+				if (link != null && !link.equals(resolveToZeroPeriod)) {
                     Document remoteDoc = parseXML(link);
                     // Earlier the calling xlink node can be directly replaced with the remoteDoc's root element.
                     // But this is no longer possible, because we add a manual root element.
@@ -261,9 +262,9 @@ public class XLinkResolver {
 		}
 		
 		// we only allow http links
-		if (href != null && (!href.startsWith(Definitions.PROTOCOL) && !href.startsWith(Definitions.SECURE_PROTOCOL)))
-			throw new XLinkException("Only HTTP links are allowed!");
-		
+		if (href != null && (!href.startsWith(Definitions.PROTOCOL) && !href.startsWith(Definitions.SECURE_PROTOCOL) && !href.startsWith(Definitions.RESOLVE_TO_ZERO)))
+			throw new XLinkException("Only HTTP links or urn:mpeg:dash:resolve-to-zero:2013 are allowed!");
+
 		return href;
 	}
 	


### PR DESCRIPTION
- Necessary modifications implemented in the code to accommodate urn:mpeg:dash:resolve-to-zero:2013 
- First change : In the schema, if a period has such has to be resolved to zero, then that period need not have any adaption set, segment timeline or segment template
- Second change: In the xlink resolver, xlink:href can also the above mentioned URI, apart from the usual http[s] links