### PR TITLE
Commit for adaptation set switching.

### DIFF
--- a/webfe/mpdvalidator/schematron/output/val_schema.xsl
+++ b/webfe/mpdvalidator/schematron/output/val_schema.xsl
@@ -614,6 +614,22 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
+         <xsl:when test="if ((descendant::dash:SupplementalProperty/@value = following-sibling::dash:AdaptationSet/@id) and (@segmentAlignment='true') and (following-sibling::dash:AdaptationSet/@segmentAlignment = 'false')) then false() else true()"/>
+         <xsl:otherwise>
+            <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                xmlns:schold="http://www.ascc.net/xml/schematron"
+                                xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+                                test="if ((descendant::dash:SupplementalProperty/@value = following-sibling::dash:AdaptationSet/@id) and (@segmentAlignment='true') and (following-sibling::dash:AdaptationSet/@segmentAlignment = 'false')) then false() else true()">
+               <xsl:attribute name="location">
+                  <xsl:apply-templates select="." mode="schematron-get-full-path"/>
+               </xsl:attribute>
+               <svrl:text>If the content author signals the ability of Adaptation Set switching and as @segmentAlignment or @subsegmentAlignment are set to TRUE for one Adaptation Set, the (Sub)Segment alignment shall hold for all Representations in all Adaptation Sets for which the @id value is included in the @value attribute of the Supplemental descriptor.</svrl:text>
+            </svrl:failed-assert>
+         </xsl:otherwise>
+      </xsl:choose>
+
+		    <!--ASSERT -->
+<xsl:choose>
          <xsl:when test="if ((@lang = descendant::dash:ContentComponent/@lang) or (@contentType = descendant::dash:ContentComponent/@contentType) or (@par = descendant::dash:ContentComponent/@par)) then false() else true()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/webfe/mpdvalidator/schematron/schematron.xsd
+++ b/webfe/mpdvalidator/schematron/schematron.xsd
@@ -60,6 +60,8 @@
 		<rule context="dash:AdaptationSet">
 			<!-- R3.0 -->
 			<assert test="if (@id = preceding-sibling::dash:AdaptationSet/@id) then false() else true()">The id of each AdaptationSet within a Period shall be unique.</assert>
+			<!-- DASH-IF v 3.3 Section 3.8  -->
+			<assert test="if ((descendant::dash:SupplementalProperty/@value = following-sibling::dash:AdaptationSet/@id) and (@segmentAlignment='true') and (following-sibling::dash:AdaptationSet/@segmentAlignment = 'false')) then false() else true()">If the content author signals the ability of Adaptation Set switching and as @segmentAlignment or @subsegmentAlignment are set to TRUE for one Adaptation Set, the (Sub)Segment alignment shall hold for all Representations in all Adaptation Sets for which the @id value is included in the @value attribute of the Supplemental descriptor.</assert>
 			<!-- R3.1 -->
 			<assert test="if ((@lang = descendant::dash:ContentComponent/@lang) or (@contentType = descendant::dash:ContentComponent/@contentType) or (@par = descendant::dash:ContentComponent/@par)) then false() else true()">Attributes from the AdaptationSet shall not be repeated in the descendanding ContentComponent elements.</assert>
 			<!-- R3.2 -->


### PR DESCRIPTION
This PR is related to this text in the DASH-IF IOP v3.3:

`If the content author signals the ability of Adaptation Set switching and as @segmentAlignment or @subsegmentAlignment are set to TRUE for one Adaptation Set, the (Sub)Segment alignment shall hold for all Representations in all Adaptation Sets for which the @id value is included in the @value attribute of the Supplemental descriptor.`

The following .mpd will fail. Notice **Adaptation set 2** has **segmentAlignment=false**, whereas **Adaptation set 1** has **segmentAlignment=true**.

```xml
<?xml version="1.0"?>
<!-- MPD file Generated with GPAC version 0.6.2-DEV-rev698-g8cee692-master  at 2016-09-13T09:49:14.312Z-->
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H12M14.167S" maxSegmentDuration="PT0H0M2.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264">
 <ProgramInformation moreInformationURL="http://gpac.io">
  <Title>manifest.mpd generated by GPAC</Title>
 </ProgramInformation>

 <Period duration="PT0H12M14.167S">
  <AdaptationSet id="1" segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="2" />
   <Representation id="1" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="999120">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h264_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_1000k_h264_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="2" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2003095">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h264_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_2000k_h264_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet id="2" segmentAlignment="false" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1" />
   <Representation id="3" mimeType="video/mp4" codecs="hev1.1.6.L120.90" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="1029626">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h265_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_1000k_h265_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="4" mimeType="video/mp4" codecs="hev1.1.6.L120.90" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2067007">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h265_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_2000k_h265_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet segmentAlignment="true" lang="eng">
   <Representation id="5" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="34189">
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    <SegmentTemplate timescale="48000" media="tears_of_steel_1080p_audio_32k_dash_track1_$Number$.m4s" startNumber="1" duration="95232" initialization="tears_of_steel_1080p_audio_32k_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  </Period>
</MPD>
```

The following is a correct conforming .mpd

```xml
<?xml version="1.0"?>
<!-- MPD file Generated with GPAC version 0.6.2-DEV-rev698-g8cee692-master  at 2016-09-13T09:49:14.312Z-->
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H12M14.167S" maxSegmentDuration="PT0H0M2.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264">
 <ProgramInformation moreInformationURL="http://gpac.io">
  <Title>manifest.mpd generated by GPAC</Title>
 </ProgramInformation>

 <Period duration="PT0H12M14.167S">
  <AdaptationSet id="1" segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="2" />
   <Representation id="1" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="999120">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h264_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_1000k_h264_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="2" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2003095">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h264_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_2000k_h264_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet id="2" segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1" />
   <Representation id="3" mimeType="video/mp4" codecs="hev1.1.6.L120.90" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="1029626">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h265_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_1000k_h265_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="4" mimeType="video/mp4" codecs="hev1.1.6.L120.90" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2067007">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h265_dash_track1_$Number$.m4s" startNumber="1" duration="24576" initialization="tears_of_steel_1080p_2000k_h265_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet segmentAlignment="true" lang="eng">
   <Representation id="5" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="34189">
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    <SegmentTemplate timescale="48000" media="tears_of_steel_1080p_audio_32k_dash_track1_$Number$.m4s" startNumber="1" duration="95232" initialization="tears_of_steel_1080p_audio_32k_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  </Period>
</MPD>
```