### PR TITLE
Update for the mimeType in the adaptationSet level. 

### DIFF
--- a/webfe/mpdvalidator/schematron/output/val_schema.xsl
+++ b/webfe/mpdvalidator/schematron/output/val_schema.xsl
@@ -899,6 +899,22 @@
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
+
+		    <!--ASSERT -->
+<xsl:choose>
+         <xsl:when test="if (@mimeType and not((@mimeType = 'video/mp4') or (@mimeType = 'audio/mp4') or (@mimeType = 'application/mp4'))) then false() else true()"/>
+         <xsl:otherwise>
+            <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                xmlns:schold="http://www.ascc.net/xml/schematron"
+                                xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+                                test="if (@mimeType and not((@mimeType = 'video/mp4') or (@mimeType = 'audio/mp4') or (@mimeType = 'application/mp4'))) then false() else true()">
+               <xsl:attribute name="location">
+                  <xsl:apply-templates select="." mode="schematron-get-full-path"/>
+               </xsl:attribute>
+               <svrl:text> DASH-IF IOP (v3.3) Section 3.2.13: For Adaptation Sets the mimeType shall be one of the four following type: "video/mp4", "audio/mp4", or "application/mp4"</svrl:text>
+            </svrl:failed-assert>
+         </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="*|comment()|processing-instruction()" mode="M6"/>
    </xsl:template>
    <xsl:template match="text()" priority="-1" mode="M6"/>
@@ -960,6 +976,22 @@
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>
                <svrl:text>Either the Representation or the containing AdaptationSet shall have the mimeType attribute.</svrl:text>
+            </svrl:failed-assert>
+         </xsl:otherwise>
+      </xsl:choose>
+
+		    <!--ASSERT -->
+<xsl:choose>
+         <xsl:when test="if (@mimeType and following-sibling::dash:Representation/@mimeType and not(following-sibling::dash:Representation/@mimeType = @mimeType)) then false() else true()"/>
+         <xsl:otherwise>
+            <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                xmlns:schold="http://www.ascc.net/xml/schematron"
+                                xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+                                test="if (@mimeType and following-sibling::dash:Representation/@mimeType and not(following-sibling::dash:Representation/@mimeType = @mimeType)) then false() else true()">
+               <xsl:attribute name="location">
+                  <xsl:apply-templates select="." mode="schematron-get-full-path"/>
+               </xsl:attribute>
+               <svrl:text>DASH-IF IOP (v3.3), Section 3.2.13 : "In contrast to MPEG-DASH which does not prohibit the use of multiplexed Representations, in the DASH-IF IOPs one Adaptation Set always contains exactly a single media type.".</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/webfe/mpdvalidator/schematron/schematron.xsd
+++ b/webfe/mpdvalidator/schematron/schematron.xsd
@@ -74,19 +74,19 @@
 			<assert test="if (descendant::dash:Representation/@width &lt; @minWidth or descendant::dash:Representation/@width > @maxWidth) then false() else true()">The value of the width attribute shall be in the range defined by the AdaptationSet.</assert>
 			<!-- R3.6 -->
 			<assert test="if (descendant::dash:Representation/@height &lt; @minHeight or descendant::dash:Representation/@height > @maxHeight) then false() else true()">The value of the height attribute shall be in the range defined by the AdaptationSet.</assert>
-                        <!-- R3.7 -->
+			<!-- R3.7 -->
 			<assert test="if (count(child::dash:Representation)=0) then false() else true()">An AdaptationSet shall have at least one Representation element.</assert>
 			<!-- R3.8 -->
 			<assert test="if ((child::dash:SegmentBase and child::dash:SegmentTemplate and child::dash:SegmentList) or (child::dash:SegmentBase and child::dash:SegmentTemplate) or (child::dash:SegmentBase and child::dash:SegmentList) or (child::dash:SegmentTemplate and child::dash:SegmentList)) then false() else true()">At most one of SegmentBase, SegmentTemplate and SegmentList shall be defined in AdaptationSet.</assert>
 			<!-- R3.9 -->
-                        <assert test="if ((@minFrameRate and (descendant::dash:Representation/@frameRate &lt; @minFrameRate)) or (@maxFrameRate and (descendant::dash:Representation/@frameRate > @maxFrameRate))) then false() else true()">ISO/IEC 23009-1 Section 5.3.3.2: The value of the frameRate attribute shall be in the range defined by the AdaptationSet.</assert>
-                        <!-- RD3.0	DASH-IF -->
+			<assert test="if ((@minFrameRate and (descendant::dash:Representation/@frameRate &lt; @minFrameRate)) or (@maxFrameRate and (descendant::dash:Representation/@frameRate > @maxFrameRate))) then false() else true()">ISO/IEC 23009-1 Section 5.3.3.2: The value of the frameRate attribute shall be in the range defined by the AdaptationSet.</assert>
+			<!-- RD3.0	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and @contentType='video' and not(@par)) then false() else true()"> DASH-IF IOP Section 3.2.4: "For any Adaptation Sets with value of the @contentType="video" the following attributes shall be present: @par" violated here</assert >
 			<!-- RD3.1	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and @contentType='video' and (@scanType and not(@scanType='progressive'))) then false() else true()"> DASH-IF IOP Section 3.2.4: "For Adaptation Set or for any Representation within an Adaptation Set with value of the @contentType="video" the attribute @scanType shall either not be present or shall be set to 'progressive' ", violated here</assert >
 			<!-- RD3.2	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and @contentType='audio' and not(@lang)) then false() else true()"> DASH-IF IOP Section 3.2.4: "For any Adaptation Sets with value of the @contentType="audio" the following attributes shall be present: @lang" violated here</assert >
-                        <!-- RD3.3	DASH-IF -->
+			<!-- RD3.3	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and @contentType='video' and not(@maxWidth) and not(@width)) then false() else true()"> DASH-IF IOP Section 3.2.4: "For any Adaptation Sets with @contentType="video" the following attributes shall be present: @maxWidth or @width" violated here</assert >
 			<!-- RD3.4	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and @contentType='video' and not(@maxHeight) and not(@height)) then false() else true()"> DASH-IF IOP Section 3.2.4: "For any Adaptation Sets with @contentType="video" the following attributes shall be present: @maxHeight or @height" violated here</assert >
@@ -95,8 +95,10 @@
 			<!-- RD3.6	DASH-IF -->
 			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and contains(ancestor::dash:MPD/@profiles, 'urn:mpeg:dash:profile:isoff-live:2011' and (not(@segmentAlignment) or @segmentAlignment='false'))) then false() else true()"> DASH-IF IOP Section 3.2.2.2: For Live Profile @segmentAlignment shall be set to true for all Adaptation Sets</assert >
                         <!-- RD3.7	DASH-IF -->
-                        <assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and contains(ancestor::dash:MPD/@profiles, 'urn:mpeg:dash:profile:isoff-ondemand:2011' and (not(@subSegmentAlignment) or @subSegmentAlignment='false'))) then false() else true()"> DASH-IF IOP Section 3.2.2.2: For On-Demand Profile @subSegmentAlignment shall be set to true for all Adaptation Sets</assert >
-                </rule>
+			<assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dash') and contains(ancestor::dash:MPD/@profiles, 'urn:mpeg:dash:profile:isoff-ondemand:2011' and (not(@subSegmentAlignment) or @subSegmentAlignment='false'))) then false() else true()"> DASH-IF IOP Section 3.2.2.2: For On-Demand Profile @subSegmentAlignment shall be set to true for all Adaptation Sets</assert >
+			<!-- RD3.7	DASH-IF -->
+			<assert test="if (@mimeType and not((@mimeType = 'video/mp4') or (@mimeType = 'audio/mp4') or (@mimeType = 'application/mp4'))) then false() else true()"> DASH-IF IOP (v3.3) Section 3.2.13: For Adaptation Sets the mimeType shall be one of the four following type: "video/mp4", "audio/mp4", or "application/mp4"</assert >
+			</rule>
 	</pattern>
 
 	<pattern name="ContentComponent element">
@@ -111,6 +113,8 @@
 		<rule context="dash:Representation">
 			<!-- R5.0 -->
 			<assert test="if (not(@mimeType) and not(parent::dash:AdaptationSet/@mimeType)) then false() else true()">Either the Representation or the containing AdaptationSet shall have the mimeType attribute.</assert>
+			<!-- R5.0 -->
+			<assert test="if (@mimeType and following-sibling::dash:Representation/@mimeType and not(following-sibling::dash:Representation/@mimeType = @mimeType)) then false() else true()">DASH-IF IOP (v3.3), Section 3.2.13 : "In contrast to MPEG-DASH which does not prohibit the use of multiplexed Representations, in the DASH-IF IOPs one Adaptation Set always contains exactly a single media type.".</assert>
 			<!-- R5.1 -->
 			<assert test="if (not(child::dash:SegmentTemplate or parent::dash:AdaptationSet/dash:SegmentTemplate or ancestor::dash:Period/dash:SegmentTemplate) and (contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(ancestor::dash:MPD/@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(parent::dash:AdaptationSet/@profiles, 'urn:mpeg:dash:profile:isoff-live:2011'))) then false() else true()">For live profile, the SegmentTemplate element shall be present on at least one of the three levels, the Period level containing the Representation, the Adaptation Set containing the Representation, or on Representation level itself.</assert>
 			<!-- R5.2 -->


### PR DESCRIPTION
This changes correspond to the latest update in the DASH-IF IOP v3.3 relating to the Adaptation Set Media Type. Specifically, two checks are implemented:

- In the DASH-IF IOPs one Adaptation Set always contains exactly a single media type.
- The mimeType of adaptation set shall be one of the following three : "video/mp4", "audio/mp4" or "application/mp4".

The following is a correct .mpd:

``` xml
  <AdaptationSet segmentAlignment="true" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <Representation id="1" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="1013045">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h264_24_dash_track1_$Number$.m4s" startNumber="1" duration="12288" initialization="tears_of_steel_1080p_1000k_h264_24_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="2" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2020878">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h264_24_dash_track1_$Number$.m4s" startNumber="1" duration="12288" initialization="tears_of_steel_1080p_2000k_h264_24_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet segmentAlignment="true" lang="eng">
   <Representation id="3" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="34881">
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    <SegmentTemplate timescale="48000" media="tears_of_steel_1080p_audio_32k_dash_track1_$Number$.m4s" startNumber="1" duration="47104" initialization="tears_of_steel_1080p_audio_32k_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
```

The following will raise an conformance error, because it contains two errors. A wrong mimeType and also an single adaptation set has multiple media representations. 

``` xml
 <AdaptationSet segmentAlignment="true" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="eng">
   <Representation id="1" mimeType="video1/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="1013045">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_1000k_h264_24_dash_track1_$Number$.m4s" startNumber="1" duration="12288" initialization="tears_of_steel_1080p_1000k_h264_24_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="2" mimeType="video/mp4" codecs="avc1.640028" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2020878">
    <SegmentTemplate timescale="12288" media="tears_of_steel_1080p_2000k_h264_24_dash_track1_$Number$.m4s" startNumber="1" duration="12288" initialization="tears_of_steel_1080p_2000k_h264_24_dash_track1_init.mp4"/>
   </Representation>
   <Representation id="3" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="34881">
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    <SegmentTemplate timescale="48000" media="tears_of_steel_1080p_audio_32k_dash_track1_$Number$.m4s" startNumber="1" duration="47104" initialization="tears_of_steel_1080p_audio_32k_dash_track1_init.mp4"/>
   </Representation>
  </AdaptationSet>
```
 