### PR TITLE
Fix for the minWidth/minHeight issue in the confromance software

### DIFF
--- a/webfe/mpdvalidator/schematron/output/val_schema.xsl
+++ b/webfe/mpdvalidator/schematron/output/val_schema.xsl
@@ -686,12 +686,12 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
-         <xsl:when test="if (descendant::dash:Representation/@width &lt; @minWidth or descendant::dash:Representation/@width &gt; @maxWidth) then false() else true()"/>
+         <xsl:when test="if (descendant::dash:Representation/@width &gt; @maxWidth) then false() else true()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
                                 xmlns:schold="http://www.ascc.net/xml/schematron"
                                 xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="if (descendant::dash:Representation/@width &lt; @minWidth or descendant::dash:Representation/@width &gt; @maxWidth) then false() else true()">
+                                test="if (descendant::dash:Representation/@width &gt; @maxWidth) then false() else true()">
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>
@@ -702,12 +702,12 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
-         <xsl:when test="if (descendant::dash:Representation/@height &lt; @minHeight or descendant::dash:Representation/@height &gt; @maxHeight) then false() else true()"/>
+         <xsl:when test="if (descendant::dash:Representation/@height &gt; @maxHeight) then false() else true()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
                                 xmlns:schold="http://www.ascc.net/xml/schematron"
                                 xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="if (descendant::dash:Representation/@height &lt; @minHeight or descendant::dash:Representation/@height &gt; @maxHeight) then false() else true()">
+                                test="if (descendant::dash:Representation/@height &gt; @maxHeight) then false() else true()">
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>

--- a/webfe/mpdvalidator/schematron/schematron.xsd
+++ b/webfe/mpdvalidator/schematron/schematron.xsd
@@ -71,9 +71,9 @@
 			<!-- R3.4 -->
 			<assert test="if (descendant::dash:Representation/@bandwidth &lt; @minBandwidth or descendant::dash:Representation/@bandwidth > @maxBandwidth) then false() else true()">The value of the bandwidth attribute shall be in the range defined by the AdaptationSet.</assert>
 			<!-- R3.5 -->
-			<assert test="if (descendant::dash:Representation/@width &lt; @minWidth or descendant::dash:Representation/@width > @maxWidth) then false() else true()">The value of the width attribute shall be in the range defined by the AdaptationSet.</assert>
+			<assert test="if (descendant::dash:Representation/@width > @maxWidth) then false() else true()">The value of the width attribute shall be in the range defined by the AdaptationSet.</assert>
 			<!-- R3.6 -->
-			<assert test="if (descendant::dash:Representation/@height &lt; @minHeight or descendant::dash:Representation/@height > @maxHeight) then false() else true()">The value of the height attribute shall be in the range defined by the AdaptationSet.</assert>
+			<assert test="if (descendant::dash:Representation/@height > @maxHeight) then false() else true()">The value of the height attribute shall be in the range defined by the AdaptationSet.</assert>
 			<!-- R3.7 -->
 			<assert test="if (count(child::dash:Representation)=0) then false() else true()">An AdaptationSet shall have at least one Representation element.</assert>
 			<!-- R3.8 -->


### PR DESCRIPTION
According to IOP 4.1 "The attributes @minwidth and @minheight should not be present. If present, they may be smaller than the smallest @width or smallest @height in the Adaptation Set."

The current validation failure in case of @width < @minWidth and @height < @minHeight was contradicting with the above IOP statement. 

This fix is provided for this contradiction.